### PR TITLE
align hackathon scoring function parameters with function definition

### DIFF
--- a/portal/hackathons/services.py
+++ b/portal/hackathons/services.py
@@ -119,7 +119,7 @@ def submission(hackathon, user, file):
         raise RuntimeError('Invalid input')
 
     # noinspection PyUnresolvedReferences,PyUnboundLocalVariable
-    score = glob['score'](y_pred, y_true)
+    score = glob['score'](y_true, y_pred)
     models.Submission.objects.create(
         hackathon=hackathon,
         content_type=ContentType.objects.get_for_model(user._meta.model),


### PR DESCRIPTION
The hackathon grader calls the scoring function in with the arguments in reverse order, throwing a `continuous format is not supported` error in the `roc_auc_score` function, this PR fixes that.