### PR TITLE
Fix/instructor filters issue 5

### DIFF
--- a/portal/academy/serializers.py
+++ b/portal/academy/serializers.py
@@ -40,6 +40,7 @@ class ChecksumSerializer(serializers.ModelSerializer):
 class InstructorsViewFiltersSerializer(serializers.Serializer):
     user_id = serializers.IntegerField(required=False)
     spc_code = serializers.CharField(required=False)
+    unit_code = serializers.CharField(required=False)
     grade_status = serializers.ChoiceField(required=False, choices=models.Grade.STATUSES)
     score__gte = serializers.FloatField(required=False)
     score__lte = serializers.FloatField(required=False)

--- a/portal/academy/serializers.py
+++ b/portal/academy/serializers.py
@@ -41,3 +41,5 @@ class InstructorsViewFiltersSerializer(serializers.Serializer):
     user_id = serializers.IntegerField(required=False)
     spc_code = serializers.CharField(required=False)
     grade_status = serializers.ChoiceField(required=False, choices=models.Grade.STATUSES)
+    score__gte = serializers.FloatField(required=False)
+    score__lte = serializers.FloatField(required=False)

--- a/portal/academy/serializers.py
+++ b/portal/academy/serializers.py
@@ -35,3 +35,9 @@ class ChecksumSerializer(serializers.ModelSerializer):
                 grade.save()
 
         return instance
+
+
+class InstructorsViewFiltersSerializer(serializers.Serializer):
+    user_id = serializers.IntegerField(required=False)
+    spc_code = serializers.CharField(required=False)
+    grade_status = serializers.ChoiceField(required=False, choices=models.Grade.STATUSES)

--- a/portal/academy/templatetags/grade_tags.py
+++ b/portal/academy/templatetags/grade_tags.py
@@ -4,6 +4,6 @@ from django import template
 register = template.Library()
 
 
-@register.inclusion_tag('academy/grade.html')
-def show_grade(grade):
-    return {'grade': grade}
+@register.inclusion_tag('academy/grade.html', takes_context=True)
+def show_grade(context, grade):
+    return {'grade': grade, 'user': context["user"]}

--- a/portal/academy/templatetags/query_param_tags.py
+++ b/portal/academy/templatetags/query_param_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def add_query_param(context, field_name, value):
+    params = context.request.GET.copy()
+    params[field_name] = value
+
+    return '?{}'.format(params.urlencode()) if params else ''

--- a/portal/academy/views.py
+++ b/portal/academy/views.py
@@ -6,6 +6,9 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, ListView, RedirectView
 from rest_framework import generics
 from rest_framework.settings import import_from_string
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.utils.translation import ugettext_lazy as _
 
 from portal.academy import models, serializers
 
@@ -109,11 +112,31 @@ class InstructorUserListView(InstructorMixin, ListView):
     queryset = get_user_model().objects.filter(student=True)
     template_name = 'academy/instructor/user_list.html'
 
+    def get_queryset(self):
+        user_id = self.request.GET.get("user_id")
+        if user_id:
+            return self.queryset.filter(id=user_id)
+        return self.queryset.all()
+
     # noinspection PyAttributeOutsideInit
     def get(self, request, *args, **kwargs):
-        self.object_list = self.get_queryset()
+        # Validate query params
+        validator = serializers.InstructorsViewFiltersSerializer(data=self.request.GET)
+        if not validator.is_valid():
+            msg = " ".join([f"Filter '{k}': {v[0].lower()}" for k,v in validator.errors.items()])
+            messages.error(request, _(msg))
+            return redirect('academy:instructor-user-list')
+        query_params = validator.validated_data
 
-        specializations = models.Specialization.objects.order_by('code')
+        self.object_list = self.get_queryset()
+        specializations = models.Specialization.objects
+
+        grade_status = query_params.get("grade_status")
+        spc_code = query_params.get("spc_code")
+        if spc_code:
+            specializations = specializations.filter(code=spc_code)
+
+        specializations = specializations.order_by('code')
         spc_list = []
         unit_list = []
         max_score = 0
@@ -137,8 +160,11 @@ class InstructorUserListView(InstructorMixin, ListView):
                     user_data['grades'].append(None)
 
                 else:
-                    grade, _ = models.Grade.objects.get_or_create(student=user,
-                                                                  unit=unit)
+                    grade, __ = models.Grade.objects.get_or_create(student=user,
+                                                                   unit=unit)
+                    if grade_status and grade.status != grade_status:
+                        user_data['grades'].append(None)
+                        continue
                     if grade.status == 'graded':
                         total_score += grade.score
                     user_data['grades'].append(grade)

--- a/portal/academy/views.py
+++ b/portal/academy/views.py
@@ -134,6 +134,7 @@ class InstructorUserListView(InstructorMixin, ListView):
         grade_status = query_params.get("grade_status")
         score__gte = query_params.get("score__gte")
         score__lte = query_params.get("score__lte")
+        unit_code = query_params.get("unit_code")
         spc_code = query_params.get("spc_code")
         if spc_code:
             specializations = specializations.filter(code=spc_code)
@@ -143,11 +144,13 @@ class InstructorUserListView(InstructorMixin, ListView):
         unit_list = []
         max_score = 0
         for spc in specializations:
-            qs = (models.Unit.objects
-                  .filter(specialization=spc)
-                  .order_by('due_date'))
-            spc_list.append(spc)
+            qs = models.Unit.objects.filter(specialization=spc)
+            if unit_code:
+                qs = qs.filter(code=unit_code)
+            qs = qs.order_by('due_date')
             max_score += qs.count() * 20
+            spc.unit_count = qs.count()
+            spc_list.append(spc)
             if qs.exists():
                 unit_list += list(qs)
             else:

--- a/portal/academy/views.py
+++ b/portal/academy/views.py
@@ -123,7 +123,7 @@ class InstructorUserListView(InstructorMixin, ListView):
         # Validate query params
         validator = serializers.InstructorsViewFiltersSerializer(data=self.request.GET)
         if not validator.is_valid():
-            msg = " ".join([f"Filter '{k}': {v[0].lower()}" for k,v in validator.errors.items()])
+            msg = " ".join([f"Filter '{k}': {v[0].lower()}" for k, v in validator.errors.items()])
             messages.error(request, _(msg))
             return redirect('academy:instructor-user-list')
         query_params = validator.validated_data
@@ -132,6 +132,8 @@ class InstructorUserListView(InstructorMixin, ListView):
         specializations = models.Specialization.objects
 
         grade_status = query_params.get("grade_status")
+        score__gte = query_params.get("score__gte")
+        score__lte = query_params.get("score__lte")
         spc_code = query_params.get("spc_code")
         if spc_code:
             specializations = specializations.filter(code=spc_code)
@@ -168,6 +170,10 @@ class InstructorUserListView(InstructorMixin, ListView):
                     if grade.status == 'graded':
                         total_score += grade.score
                     user_data['grades'].append(grade)
+            if score__gte and total_score < score__gte:
+                continue
+            if score__lte and total_score > score__lte:
+                continue
             user_data['total_score'] = total_score
             object_list.append(user_data)
 

--- a/portal/templates/academy/grade.html
+++ b/portal/templates/academy/grade.html
@@ -10,7 +10,7 @@
     {% endif %}
   </a>
 {% else %}
-{% if not request.user.student %}<a href="{% add_query_param 'grade_status' grade.status %}">{% endif %}
+{% if not user.student %}<a href="{% add_query_param 'grade_status' grade.status %}">{% endif %}
   <span class="badge
       {% if grade.status == "never-submitted" %}badge-warning
       {% elif grade.status == "failed" %}badge-danger
@@ -20,5 +20,5 @@
       {% endif %}">
     {{ grade.get_status_display }}
   </span>
-  {% if not request.user.student %}</a>{% endif %}
+  {% if not user.student %}</a>{% endif %}
 {% endif %}

--- a/portal/templates/academy/grade.html
+++ b/portal/templates/academy/grade.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load query_param_tags %}
 
 {% if grade.status == "graded" %}
   <a href="{% get_media_prefix %}{{ grade.notebook }}">
@@ -9,6 +10,7 @@
     {% endif %}
   </a>
 {% else %}
+{% if not request.user.student %}<a href="{% add_query_param 'grade_status' grade.status %}">{% endif %}
   <span class="badge
       {% if grade.status == "never-submitted" %}badge-warning
       {% elif grade.status == "failed" %}badge-danger
@@ -18,4 +20,5 @@
       {% endif %}">
     {{ grade.get_status_display }}
   </span>
+  {% if not request.user.student %}</a>{% endif %}
 {% endif %}

--- a/portal/templates/academy/instructor/user_list.html
+++ b/portal/templates/academy/instructor/user_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% load grade_tags %}
+{% load query_param_tags %}
 
 {% block title %}Students{% endblock %}
 
@@ -8,7 +9,7 @@
   <div class="container">
     <div class="row mb-5 mt-5">
       <div class="col">
-        <h1>Students</h1>
+        <h1><a href="{% url 'academy:instructor-user-list' %}" class="text-dark" title="See all students">Students</a></h1>
       </div>
     </div>
 
@@ -18,7 +19,9 @@
           <th scope="col" rowspan="2">Name</th>
           <th scope="col" rowspan="2">Total</th>
           {% for spc in spc_list %}
-            <th scope="col" colspan="{{ spc.units.count }}">{{ spc.code }}</th>
+          <th scope="col" colspan="{{ spc.units.count }}">
+            <a href="{% add_query_param 'spc_code' spc.code %}" class="text-dark" title="Filter by specialization">{{ spc.code }}</a>
+          </th>
           {% endfor %}
         </tr>
         <tr>
@@ -30,7 +33,7 @@
       <tbody>
       {% for obj in object_list %}
         <tr>
-          <th>{{ obj.user.username }}</th>
+          <th><a href="{% add_query_param 'user_id' obj.user.id %}" class="text-dark" title="Filter by student">{{ obj.user.username }}</a></th>
           <td>{{ obj.total_score }}&#47;{{ max_score }}</td>
           {% for grade in obj.grades %}
           <td>{% show_grade grade %}</td>

--- a/portal/templates/academy/instructor/user_list.html
+++ b/portal/templates/academy/instructor/user_list.html
@@ -34,7 +34,7 @@
       {% for obj in object_list %}
         <tr>
           <th><a href="{% add_query_param 'user_id' obj.user.id %}" class="text-dark" title="Filter by student">{{ obj.user.username }}</a></th>
-          <td>{{ obj.total_score }}&#47;{{ max_score }}</td>
+          <td><a href="{% add_query_param 'score__gte' obj.total_score %}" class="text-dark">{{ obj.total_score }}&#47;{{ max_score }}</a></td>
           {% for grade in obj.grades %}
           <td>{% show_grade grade %}</td>
           {% endfor %}

--- a/portal/templates/academy/instructor/user_list.html
+++ b/portal/templates/academy/instructor/user_list.html
@@ -19,14 +19,14 @@
           <th scope="col" rowspan="2">Name</th>
           <th scope="col" rowspan="2">Total</th>
           {% for spc in spc_list %}
-          <th scope="col" colspan="{{ spc.units.count }}">
+          <th scope="col" colspan="{{ spc.unit_count }}">
             <a href="{% add_query_param 'spc_code' spc.code %}" class="text-dark" title="Filter by specialization">{{ spc.code }}</a>
           </th>
           {% endfor %}
         </tr>
         <tr>
           {% for unit in unit_list %}
-            <th scope="col">{{ unit.code }}</th>
+          <th scope="col"><a href="{% add_query_param 'unit_code' unit.code %}" class="text-dark" title="Filter by unit">{{ unit.code }}</a></th>
           {% endfor %}
         </tr>
       </thead>


### PR DESCRIPTION
Add filters by student_id, grade_status, specialization, unit and total grade to instructors view. Was a bit uncertain on the best way to display these filters - the simplest way seemed to simply add them in place (users just click on the student/unit/etc name) instead of adding a new area dedicated explicitly to filters. The problem may be that people don't see that they can now click - hoping instructors will discover they can do so by hovering over the links or by other means like 'word of mouth'.