### PR TITLE
[170] Run graduation eligibility update when closing a hackathon

### DIFF
--- a/portal/hackathons/views.py
+++ b/portal/hackathons/views.py
@@ -13,6 +13,7 @@ from rest_framework import generics
 from portal.users.views import StudentViewsMixin, InstructorViewsMixin
 from portal.hackathons import models, serializers, forms, services
 from portal.capstone.models import StudentApi, Capstone
+from portal.academy.services import check_graduation_status
 
 
 logger = logging.getLogger(__name__)
@@ -266,6 +267,12 @@ class InstructorHackathonAdminView(InstructorViewsMixin, generic.DetailView):
                 attendance, _ = models.Attendance.objects.get_or_create(
                     user=user, hackathon=self.object
                 )
+
+        # Update graduation eligibility status of user
+        elif new_status == "complete" and cur_status == "submissions_closed":
+            for user in get_user_model().objects.filter(is_student=True):
+                user.can_graduate = check_graduation_status(user)
+                user.save()
 
         # Delete test submissions
         elif new_status == "closed" and cur_status == "closed":


### PR DESCRIPTION
Updates at end of hackathon the graduation eligibility status according to:

>  Rule: if student has attendance (using the Attendance mentioned below) in 1st hackathon (maybe we could add a flag mandatory to hackathons) + all hackathons - 1, he’s eligible for graduation

This doesn't cover the late hackathon deliveries. For that purpose, I'll propose a change to the plan in https://github.com/LDSSA/portal/issues/149

Closes #170 