### PR TITLE
Feature: make logging less verbose

### DIFF
--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -597,14 +597,18 @@ LOGGING = {
         },
     },
     "loggers": {
-        "": {
+        "root": {
             "handlers": ["console"],
             "level": "DEBUG",
         },
         "parso": {
-            "handlers": ["console"],
             "level": "WARNING",
-            "propagate": False,
+        },
+        "botocore": {
+            "level": "WARNING",
+        },
+        "urllib3": {
+            "level": "WARNING",
         },
     },
 }

--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -610,6 +610,9 @@ LOGGING = {
         "urllib3": {
             "level": "WARNING",
         },
+        "s3transfer": {
+            "level": "WARNING",
+        },
     },
 }
 


### PR DESCRIPTION
## Changes

- `botocore` has been spamming the logs, and makes it hard to see old logs. I am changing this logger to `WARNING`. Should clean up the logs by a lot! I am also adding `s3transfer` and `urllib3` since we have a few from them as well. No need to have `DEBUG` logs coming from there

## Issue(s)

- #

