### PR TITLE
Bugfix: reset password does not validate email

### DIFF
--- a/portal/portal/hackathons/admin.py
+++ b/portal/portal/hackathons/admin.py
@@ -37,6 +37,7 @@ class TeamAdmin(admin.ModelAdmin):
         "hackathon",
     )
     list_filter = ("hackathon",)
+    filter_horizontal = ("users",)
 
 
 @admin.register(models.Attendance)

--- a/portal/portal/users/adapters.py
+++ b/portal/portal/users/adapters.py
@@ -36,6 +36,12 @@ class AccountAdapter(DefaultAccountAdapter):
 
     def clean_email(self, email):
         email = super().clean_email(email)
+        request = getattr(self, "request", None)
+        
+        # Skip unique email check if it's a password reset request
+        if request and request.path == reverse("account_reset_password"):
+            return email
+        
         if email and app_settings.UNIQUE_EMAIL:
             if EmailAddress.objects.filter(email=email).exists():
                 raise ValidationError(


### PR DESCRIPTION
## Changes

- Bugfix the reset password to not validate the email. `clean_email` is the function that needed to be modified here since it is being used by the account registration and password reset forms. This function should allow both cases, that's why I'm adding a condition for when it is a password reset, it doesn't need to validate the email.

