### PR TITLE
Change portal statuses

### DIFF
--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -474,7 +474,7 @@ CONSTANCE_CONFIG = {
     "ADMISSIONS_ACCEPTING_PAYMENT_PROFS": (True, ""),
 }
 ADMISSIONS_APPLICATIONS_STARTED_STATUSES = [
-    "admissions:applications",
+    "admissions",
     "admissions:selection",
 ]
 


### PR DESCRIPTION
## Changes

- changed admissions-applications to admissions 
`ADMISSIONS_APPLICATIONS_STARTED_STATUSES = [
    "admissions:applications",
    "admissions:selection",
]`
- there is some confusion regarding these two statuses

## Issue(s)

- None

