### PR TITLE
Circumvent scheduler

### DIFF
--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -1,7 +1,7 @@
 """Base settings to build other settings files upon."""
 
 import os
-from datetime import datetime, timedelta, timezone, date
+from datetime import date, datetime, timedelta, timezone
 
 import environ
 

--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -466,11 +466,11 @@ CONSTANCE_CONFIG = {
         "One of: admissions, admissions:applications, admissions:selection, academy",
     ),
     # Academy config
-    "ACADEMY_START": (datetime.now(timezone.utc), ""),
+    "ACADEMY_START": (datetime.date(datetime.now(timezone.utc).year,9,15), ""),
     # Admissions config
     "ADMISSIONS_CODING_TEST_DURATION": (timedelta(hours=3), ""),
-    "ADMISSIONS_APPLICATIONS_START": (datetime.now(timezone.utc), ""),
-    "ADMISSIONS_SELECTION_START": (datetime.now(timezone.utc), ""),
+    "ADMISSIONS_APPLICATIONS_START": (datetime.date(datetime.now(timezone.utc).year,7,7), ""),
+    "ADMISSIONS_SELECTION_START": (datetime.date(datetime.now(timezone.utc).year,8,3), ""),
     "ADMISSIONS_ACCEPTING_PAYMENT_PROFS": (True, ""),
 }
 ADMISSIONS_APPLICATIONS_STARTED_STATUSES = [

--- a/portal/config/settings/settings.py
+++ b/portal/config/settings/settings.py
@@ -1,7 +1,7 @@
 """Base settings to build other settings files upon."""
 
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, date
 
 import environ
 
@@ -466,11 +466,11 @@ CONSTANCE_CONFIG = {
         "One of: admissions, admissions:applications, admissions:selection, academy",
     ),
     # Academy config
-    "ACADEMY_START": (datetime.date(datetime.now(timezone.utc).year,9,15), ""),
+    "ACADEMY_START": (date(datetime.now(timezone.utc).year,9,15), ""),
     # Admissions config
     "ADMISSIONS_CODING_TEST_DURATION": (timedelta(hours=3), ""),
-    "ADMISSIONS_APPLICATIONS_START": (datetime.date(datetime.now(timezone.utc).year,7,7), ""),
-    "ADMISSIONS_SELECTION_START": (datetime.date(datetime.now(timezone.utc).year,8,3), ""),
+    "ADMISSIONS_APPLICATIONS_START": (date(datetime.now(timezone.utc).year,7,7), ""),
+    "ADMISSIONS_SELECTION_START": (date(datetime.now(timezone.utc).year,8,3), ""),
     "ADMISSIONS_ACCEPTING_PAYMENT_PROFS": (True, ""),
 }
 ADMISSIONS_APPLICATIONS_STARTED_STATUSES = [

--- a/portal/portal/scheduler/management/commands/run-scheduler.py
+++ b/portal/portal/scheduler/management/commands/run-scheduler.py
@@ -48,6 +48,7 @@ def update_portal_status():
             # Disable sign ups
             #config.ACCOUNT_ALLOW_REGISTRATION = False
 
+    '''
     elif config.PORTAL_STATUS == "admissions:applications":
         if dt >= config.ADMISSIONS_SELECTION_START:
             # Selection phase starts, applicants can not longer make submissions
@@ -60,3 +61,4 @@ def update_portal_status():
 
     elif config.PORTAL_STATUS == "admissions:selection" and dt >= config.ACADEMY_START:
         config.PORTAL_STATUS = "academy"
+    '''    


### PR DESCRIPTION
## Changes

- Change academy and admissions default dates and disable automatic portal status changes to academy because the portal is constantly switching itself to academy status apparently without reason.

## Issue(s)

- None

